### PR TITLE
Make sed work on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 src/Html/WithContext.elm: codegen/Gen/Platform.elm codegen/Generate.elm
 	zsh -c "elm-codegen run --output src --flags-from =(cat ~/.elm/0.19.1/packages/elm/html/1.0.0/src/{Html.elm,Html/*.elm})"
-	sed -i 's/{-| - -}/{-|-}/' src/Html/*.elm src/Html/WithContext/*.elm
+	sed -i "" 's/{-| - -}/{-|-}/' src/Html/*.elm src/Html/WithContext/*.elm
 
 codegen/Gen/Platform.elm: codegen/helpers/Html/WithContext/Internal.elm
 	elm-codegen install


### PR DESCRIPTION
Without this argument, `sed` does not work on MacOS (it crashes the build).
I don't know if this breaks for non-macOS systems though. Could you try it out?